### PR TITLE
A few drive-by performance and SEO fixes.

### DIFF
--- a/contents/index.json
+++ b/contents/index.json
@@ -1,4 +1,5 @@
 {
   "pageId": "index",
-  "template": "pages/index.html.njk"
+  "template": "pages/index.html.njk",
+  "title": "JSConf EU 2018"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,6 +1545,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1552,13 +1559,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2272,7 +2272,6 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.5.1.tgz",
       "integrity": "sha512-M3aO8EjHebaCw6uur4C86SZqkypnoaEVo5R63FEEU0dw9wLxf/JlwWtJItShYVyQS2WDxG2It10GEe5GmVEM2Q==",
       "requires": {
-        "JSONStream": "1.3.1",
         "abbrev": "1.1.1",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -2304,6 +2303,7 @@
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
         "is-cidr": "1.0.0",
+        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.6.0",
         "lockfile": "1.0.3",
@@ -2378,24 +2378,6 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
@@ -2765,6 +2747,24 @@
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
               "bundled": true
             }
           }
@@ -8075,6 +8075,14 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8083,14 +8091,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -3,12 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>
-      {% if page.title %}
-        {{ page.title }} -
-      {% endif %}
-      {{ name }}
-    </title>
+    <title>{% if page.title %}{{ page.title }}{% endif %}</title>
     {% if page.description %}
       <meta name="description" content="{{ page.description }}">
     {% endif %}
@@ -27,9 +22,6 @@
     <script src="https://use.typekit.net/gug4wmv.js" async onload="try{Typekit.load({ async: true });}catch(e){}"></script>
   </head>
   <body>
-    <div style="height: 0; width: 0; position: absolute; visibility: hidden;">
-      {{ contents.svg['sprite.svg'].sprite }}
-    </div>
     <div class="layout-wrapper">
 
       {% block topbar %}
@@ -56,6 +48,10 @@
         {% include "../partials/footer.html.njk" %}
       {% endblock %}
 
+    </div>
+
+    <div style="height: 0; width: 0; position: absolute; visibility: hidden;">
+      {{ contents.svg['sprite.svg'].sprite }}
     </div>
 
     <script type="text/javascript">

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -4,12 +4,14 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>
-      {% if page.name %}
-        {{ page.name }} -
+      {% if page.title %}
+        {{ page.title }} -
       {% endif %}
       {{ name }}
     </title>
-    <meta name="description" content="{{ site.description }}">
+    {% if page.description %}
+      <meta name="description" content="{{ page.description }}">
+    {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -20,8 +22,9 @@
     <meta name="theme-color" content="#ffffff">
 
     <link rel="stylesheet" href="{{ contents.css["main.css"].url }}">
-    <script src="https://use.typekit.net/gug4wmv.js"></script>
-    <script>try{Typekit.load({ async: true });}catch(e){}</script>
+    <script src="{{ contents.js['main.js'].url }}" defer></script>
+    <link rel="preconnect" href="https://p.typekit.net">
+    <script src="https://use.typekit.net/gug4wmv.js" async onload="try{Typekit.load({ async: true });}catch(e){}"></script>
   </head>
   <body>
     <div style="height: 0; width: 0; position: absolute; visibility: hidden;">
@@ -54,8 +57,6 @@
       {% endblock %}
 
     </div>
-
-    <script src="{{ contents.js['main.js'].url }}"></script>
 
     <script type="text/javascript">
   var _gauges = _gauges || [];

--- a/templates/partials/topbar.html.njk
+++ b/templates/partials/topbar.html.njk
@@ -23,7 +23,7 @@
         </a>
       </div>
     </nav>
-    <a href="/https://ti.to/jsconfeu/jsconf-eu-2018" class="btn btn--undefinedpurple topbar-cta">Buy Ticket</a>
+    <a href="https://ti.to/jsconfeu/jsconf-eu-2018" class="btn btn--undefinedpurple topbar-cta">Buy Ticket</a>
     <button id="topbar-toggle" type="button" class="topbar-toggle" title="Toggle Navigation">
     </button>
   </div>


### PR DESCRIPTION
I couldn't test this yet, because `npm i` does not successfully terminate on the plane.

- Make TypeKit not block page display.
- Preconnect to TypeKit's font origin concurrently with JS download..
- Start download of JS file earlier.
- Moved SVG sprite to the end to put main content ahead in the stream.
- Use `title` instead of `name` for page title. Matches what is actually specified in JSON files.
- Switch the `meta-description` to be page based instead of site based and only print it if defined.
- Fixed a broken link to ti.to.
- Fixed homepage title